### PR TITLE
Add Italic and Strikethrough styles

### DIFF
--- a/src/core/style.rs
+++ b/src/core/style.rs
@@ -2,12 +2,14 @@
 pub enum Style {
     Bold,
     Dim,
+    Italic,
     Underlined,
     Blink,
     // invert the foreground and background colors
     Reverse,
     // useful for passwords
     Hidden,
+    Strikethrough,
 }
 
 impl Style {
@@ -15,10 +17,12 @@ impl Style {
         match self {
             Style::Bold => String::from("1"),
             Style::Dim => String::from("2"),
+            Style::Italic => String::from("3"),
             Style::Underlined => String::from("4"),
             Style::Blink => String::from("5"),
             Style::Reverse => String::from("7"),
             Style::Hidden => String::from("8"),
+            Style::Strikethrough => String::from("9"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,12 +122,16 @@ pub trait Colorful {
     fn blink(self) -> CString;
     /// Turn low intensity mode on.
     fn dim(self) -> CString;
+    /// Turn italic mode on.
+    fn italic(self) -> CString;
     /// Turn underline mode on.
     fn underlined(self) -> CString;
     /// Turn reverse mode on (invert the foreground and background colors).
     fn reverse(self) -> CString;
     /// Turn invisible text mode on (useful for passwords).
     fn hidden(self) -> CString;
+    /// Turn strikethrough mode on.
+    fn strikethrough(self) -> CString;
     /// Apply gradient color to sentences, support multiple lines.
     /// You can use `use colorful::Color;` or `use colorful::HSL;` or `use colorful::RGB;`
     /// to import colors and create gradient string.
@@ -215,9 +219,11 @@ impl<T> Colorful for T where T: StrMarker {
     fn bold(self) -> CString { self.style(Style::Bold) }
     fn blink(self) -> CString { self.style(Style::Blink) }
     fn dim(self) -> CString { self.style(Style::Dim) }
+    fn italic(self) -> CString { self.style(Style::Italic) }
     fn underlined(self) -> CString { self.style(Style::Underlined) }
     fn reverse(self) -> CString { self.style(Style::Reverse) }
     fn hidden(self) -> CString { self.style(Style::Hidden) }
+    fn strikethrough(self) -> CString { self.style(Style::Strikethrough) }
     fn gradient_with_step<C: ColorInterface>(self, color: C, step: f32) -> CString {
         let mut t = vec![];
         let mut start = color.to_hsl().h;


### PR DESCRIPTION
This PR adds two "new" styles: `Italic` and `Strikethrough`. These are important for a terminal color/ANSI library like this.

Closes #25.